### PR TITLE
Add missing array.dats and fixups for latest ATS compiler code

### DIFF
--- a/ats_basics.h
+++ b/ats_basics.h
@@ -154,6 +154,8 @@ do { \
 #define ats_caselind_mac(ty, x, ind) (((ty*)(x))ind)
 #define ats_caselptr_mac(ty, x, lab) (((ty*)(x))->lab)
 
+#define ats_caselptrind_mac(ty, x, ind) (((ty*)(x))ind)
+
 #define ats_varget_mac(ty, x) (x)
 #define ats_ptrget_mac(ty, x) (*(ty*)(x))
 

--- a/prelude/DATS/array.dats
+++ b/prelude/DATS/array.dats
@@ -1,0 +1,34 @@
+%{$
+
+typedef unsigned char byte ;
+
+//
+// HX-2010-05-24
+// In case 'memcpy' is already defined as a macro ...
+//
+#ifndef memcpy
+extern void *memcpy (void *dst, const void* src, size_t n) ;
+#endif // end of [memcpy]
+
+ats_void_type
+atspre_array_ptr_initialize_elt_tsz (
+  ats_ptr_type A
+, ats_size_type asz
+, ats_ptr_type ini
+, ats_size_type tsz
+)  {
+  int i, itsz ; int left ; ats_ptr_type p ;
+  if (asz == 0) return ;
+  memcpy (A, ini, tsz) ;
+  i = 1 ; itsz = tsz ; left = asz - i ;
+  while (left > 0) {
+    p = (ats_ptr_type)(((byte*)A) + itsz) ;
+    if (left <= i) { memcpy (p, A, left * tsz) ; return ; }
+    memcpy (p, A, itsz);
+    i = i + i ; itsz = itsz + itsz ; left = asz - i ;
+  } /* end of [while] */
+  return ;
+} /* end of [atspre_array_ptr_initialize_elt_tsz] */
+
+%} // end of [%{$]
+

--- a/start.S
+++ b/start.S
@@ -81,8 +81,8 @@ _start:
     addl $_virt_base,%esp
 
     /* Call dynamic elaboration code. */
-    call _2boot_2edats__staload
-    call _2boot_2edats__dynload
+    call ATS_2d0_2e2_2e9_2boot_2edats__staload
+    call ATS_2d0_2e2_2e9_2boot_2edats__dynload
 
     /* Call entry point in boot.dats. */
     pushl $hang
@@ -95,8 +95,8 @@ hang:
     jmp hang
 
 .data
-.global _2boot_2edats__dynload_flag
-_2boot_2edats__dynload_flag:
+.global ATS_2d0_2e2_2e9_2boot_2edats__dynload_flag
+ATS_2d0_2e2_2e9_2boot_2edats__dynload_flag:
     .int 0
 
 .bss


### PR DESCRIPTION
I tried building and came across an error with a missing prelude/dats/array.dats and some changes needed to work with the latest ATS compiler code. This commit fixed these issues for me.
